### PR TITLE
add onError in try-catch

### DIFF
--- a/src/main/java/io/reactivex/internal/observers/ConsumerSingleObserver.java
+++ b/src/main/java/io/reactivex/internal/observers/ConsumerSingleObserver.java
@@ -64,6 +64,7 @@ implements SingleObserver<T>, Disposable, LambdaConsumerIntrospection {
         } catch (Throwable ex) {
             Exceptions.throwIfFatal(ex);
             RxJavaPlugins.onError(ex);
+            onError(ex)
         }
     }
 


### PR DESCRIPTION
I don't know why It isn't pass exception to "onError" in onSuccess try-catch

Thank you for contributing to RxJava. Before pressing the "Create Pull Request" button, please consider the following points:

  - [ ] Please give a description about what and why you are contributing, even if it's trivial.

  - [ ] Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those.

  - [ ] Please include a reasonable set of unit tests if you contribute new code or change an existing one. If you contribute an operator, (if applicable) please make sure you have tests for working with an `empty`, `just`, `range` of values as well as an `error` source, with and/or without backpressure and see if unsubscription/cancellation propagates correctly.
